### PR TITLE
fix multi-core load info memory leak

### DIFF
--- a/src/Cpuinfo.cpp
+++ b/src/Cpuinfo.cpp
@@ -63,6 +63,11 @@ void Cpuinfo::update() {
       cores[i].cpu_ticks[CPU_STATE_IDLE] = coreinfo[i].cpu_ticks[CPU_STATE_IDLE];
       cores[i].cpu_ticks[CPU_STATE_NICE] = coreinfo[i].cpu_ticks[CPU_STATE_NICE];
     }
+    
+    vm_deallocate(mach_task_self(),
+                  (vm_address_t)coreinfo,
+                  sizeof(processor_cpu_load_info_data_t) * core_count
+                  );
   }
   else {
     //host

--- a/src/Cpuinfo.hpp
+++ b/src/Cpuinfo.hpp
@@ -2,6 +2,7 @@
 #define Cpuinfo_hpp
 
 #include <mach/host_info.h>
+#include <mach/vm_map.h>
 #include <mach/mach_host.h>
 #include <mach/processor_info.h>
 #include <stdio.h>


### PR DESCRIPTION
This PR fixes a memory leak when calling `host_processor_info` for `PROCESSOR_CPU_LOAD_INFO` which occurs with the "Show cores individually" setting turned on. The `coreinfo` result is an array allocated by `host_processor_info` that must be freed by the caller. The fix is to add a `vm_deallocate` for the array after using it. Without the fix, memory usage increases, and I have seen memory usage of over 2 GB after a couple days.

Before:
<img width="903" alt="before" src="https://user-images.githubusercontent.com/5288285/99773170-e17bb380-2ac0-11eb-813a-100b7fa4ab55.png">

After:
<img width="903" alt="after" src="https://user-images.githubusercontent.com/5288285/99773202-eccedf00-2ac0-11eb-9737-7d2b04b9c5bd.png">
