### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Download [Latest application zipped](dist/cpuinfo.zip?raw=true).
 or with [brew cask](http://caskroom.io/).
 
 ```sh
-brew cask install cpuinfo
+brew install --cask cpuinfo
 ```
 
 ## License


### PR DESCRIPTION
Use `brew install --cask` instead of `brew cask install`

Close #33 